### PR TITLE
Fix layout shadow

### DIFF
--- a/packages/vital-layout/src/components/Layout/index.ts
+++ b/packages/vital-layout/src/components/Layout/index.ts
@@ -13,6 +13,6 @@
  */
 
 export { LayoutClean, asLayoutToken } from './LayoutClean';
-export { vitalLayout } from './tokens';
+export { default as vitalLayout } from './tokens';
 export type { LayoutComponents, LayoutProps } from './types';
 export { default as vitalLayoutBase } from './tokens/vitalLayout';

--- a/packages/vital-layout/src/components/Layout/tokens/index.ts
+++ b/packages/vital-layout/src/components/Layout/tokens/index.ts
@@ -16,4 +16,4 @@ import vitalLayout from './vitalLayout';
 
 export { LayoutIds } from './constants';
 
-export { vitalLayout };
+export default vitalLayout;

--- a/packages/vital-templates/src/components/GenericTemplate/tokens/vitalGenericTemplate.ts
+++ b/packages/vital-templates/src/components/GenericTemplate/tokens/vitalGenericTemplate.ts
@@ -19,7 +19,7 @@ import {
   addProps,
 } from '@bodiless/fclasses';
 import { vitalImage } from '@bodiless/vital-image';
-import { vitalLayoutBase } from '@bodiless/vital-layout';
+import { vitalLayout } from '@bodiless/vital-layout';
 import { vitalFlowContainer } from '@bodiless/vital-flowcontainer';
 import { withNodeKey } from '@bodiless/core';
 import { vitalSpacing, vitalTypography } from '@bodiless/vital-elements';
@@ -34,7 +34,7 @@ const Default = asGenericTemplateToken({
      * Error in function Module.../../packages/vital-templates/src/components/GenericTemplate/tokens/vitalGenericTemplate.ts in http://localhost:
      * Cannot read properties of undefined (reading 'Default')
      */
-    PageWrapper: as(vitalLayoutBase.Default),
+    PageWrapper: vitalLayout.Default,
     // @todo breadcrumb placeholder
     Breadcrumb: addProps({ children: 'Breadcrumb Placeholder', }),
     // @todo in Hero ticket is change this to chameleon.


### PR DESCRIPTION
The issue was the way that the layotu tokens wer exported (as named export, not default) -- that caused the cannot get property of undefined error, and switching to using vitalLayoutBase in the generic template meant that your shadowed version was never being used.

Note
I think we an completely remove the __Vital__/src/componetns/Layout, ?Header, /Footer etc and just use shadowing.  afaict the Layotu is not being sued anyway (bc we haven't overridden the vital generic template, which uses the default vitalLayout.