### PR TITLE
Generate `vital-templates` API docs on build

### DIFF
--- a/packages/vital-templates/package.json
+++ b/packages/vital-templates/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "run-p build:lib",
+    "build": "run-p build:lib build:api-doc",
     "build:api-doc": "typedoc --options ../../typedoc.js --out doc/api ./src",
     "build:lib": "tsc -p ./tsconfig.json",
     "build:watch": "npm run build:lib -- --watch",


### PR DESCRIPTION
## Changes
- Add `build:api-doc` step to `build` step in `vital-templates` package.